### PR TITLE
Adds node hashbang

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { existsSync } from 'node:fs';
 import { mkdir, rm, watch, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';


### PR DESCRIPTION
This solves an issue when consuming the application for the first time via a package manager.

Replicated on Mac OS and Ubuntu.

This can be replicated very easily with `npx astro-decap-collection`.